### PR TITLE
Delayed job - add exclude queue name and support for ActiveRecord 2

### DIFF
--- a/delayed_job/monitor_delayed_jobs.rb
+++ b/delayed_job/monitor_delayed_jobs.rb
@@ -121,7 +121,7 @@ class MonitorDelayedJobs < Scout::Plugin
     report(report_hash)
 
   rescue DbConnError => err
-    STDERR.puts "ERROR: #{err.message} connecting to database"
+    error("ERROR: #{err.message} connecting to database")
   end
 
 private

--- a/delayed_job/monitor_delayed_jobs.rb
+++ b/delayed_job/monitor_delayed_jobs.rb
@@ -27,6 +27,8 @@ class MonitorDelayedJobs < Scout::Plugin
   class DbConnError < StandardError; end
 
   class DelayedJob < ActiveRecord::Base
+    self.default_timezone = :utc
+
     def self.custom_count(query_conditions)
       if new_activerecord_version?
         # ActiveRecord >= 3.x uses AREL query format
@@ -55,7 +57,6 @@ class MonitorDelayedJobs < Scout::Plugin
     end
   end
 
-  DelayedJob.default_timezone = :utc
 
   DELAYED_JOB_QUERIES = {
     :total => {

--- a/delayed_job/monitor_delayed_jobs.rb
+++ b/delayed_job/monitor_delayed_jobs.rb
@@ -13,9 +13,9 @@ class MonitorDelayedJobs < Scout::Plugin
   queue_name:
     name: Queue Name
     notes: If specified, only gather the metrics for jobs in this specific queue name. When nil, aggregate metrics from all queues. Not supported with ActiveRecord 2.x. Default is nil
-  excluded_queue_name
-    name: Excluded Queue Name
-    notes: If specified, do not gather the metrics for jobs in this specific queue name. When nil, aggregate metrics from all queues, unless queue_name specified. Not supported with ActiveRecord 2.x. Default is nil. DO NOT USE together with queue name.
+  exclude_queue_name
+    name: Exclude Queue Name
+    notes: If specified, do not gather the metrics for jobs in this specific queue name. When nil, aggregate metrics from all queues, unless queue_name specified. Not supported with ActiveRecord 2.x. Default is nil.
   EOS
 
   needs 'active_record', 'yaml', 'erb'
@@ -70,9 +70,9 @@ class MonitorDelayedJobs < Scout::Plugin
           query_hash[key] = query_hash[key].where('queue = ?', option(:queue_name))
         end
       end
-      if option(:excluded_queue_name)
+      if option(:exclude_queue_name)
         query_hash.keys.each do |key|
-          query_hash[key] = query_hash[key].where('queue <> ?', option(:excluded_queue_name))
+          query_hash[key] = query_hash[key].where('queue <> ? or queue IS NULL', option(:exclude_queue_name))
         end
       end
     else

--- a/delayed_job/monitor_delayed_jobs.rb
+++ b/delayed_job/monitor_delayed_jobs.rb
@@ -121,7 +121,7 @@ class MonitorDelayedJobs < Scout::Plugin
     report(report_hash)
 
   rescue DbConnError => err
-    error("ERROR: #{err.message} connecting to database")
+    error("ERROR: connecting to database", err.message)
   end
 
 private
@@ -131,8 +131,8 @@ private
     # Ensure path to db config provided
     if !app_path or app_path.empty?
       raise DbConnError.new(
-        "The path to the Rails Application wasn't provided.",
-        "Please provide the full path to the Rails Application (ie - /var/www/apps/APP_NAME/current)"
+        "The path to the Rails Application wasn't provided.
+        Please provide the full path to the Rails Application (ie - /var/www/apps/APP_NAME/current)"
       )
     end
 
@@ -140,8 +140,8 @@ private
 
     unless File.exist?(db_config_path)
       raise DbConnError.new(
-        "The database config file could not be found at: #{db_config_path}",
-        "Please ensure the path to the Rails Application is correct."
+        "The database config file could not be found at: #{db_config_path}
+        Please ensure the path to the Rails Application is correct."
       )
     end
 

--- a/delayed_job/monitor_delayed_jobs.rb
+++ b/delayed_job/monitor_delayed_jobs.rb
@@ -130,13 +130,19 @@ private
 
     # Ensure path to db config provided
     if !app_path or app_path.empty?
-      raise DbConnError.new("The path to the Rails Application wasn't provided.","Please provide the full path to the Rails Application (ie - /var/www/apps/APP_NAME/current)")
+      raise DbConnError.new(
+        "The path to the Rails Application wasn't provided.",
+        "Please provide the full path to the Rails Application (ie - /var/www/apps/APP_NAME/current)"
+      )
     end
 
     db_config_path = app_path + '/config/database.yml'
 
     unless File.exist?(db_config_path)
-      raise DbConnError.new("The database config file could not be found.", "The database config file could not be found at: #{db_config_path}. Please ensure the path to the Rails Application is correct.")
+      raise DbConnError.new(
+        "The database config file could not be found at: #{db_config_path}",
+        "Please ensure the path to the Rails Application is correct."
+      )
     end
 
     db_config = YAML::load(ERB.new(File.read(db_config_path)).result)

--- a/delayed_job/monitor_delayed_jobs.rb
+++ b/delayed_job/monitor_delayed_jobs.rb
@@ -13,6 +13,9 @@ class MonitorDelayedJobs < Scout::Plugin
   queue_name:
     name: Queue Name
     notes: If specified, only gather the metrics for jobs in this specific queue name. When nil, aggregate metrics from all queues. Not supported with ActiveRecord 2.x. Default is nil
+  excluded_queue_name
+    name: Excluded Queue Name
+    notes: If specified, do not gather the metrics for jobs in this specific queue name. When nil, aggregate metrics from all queues, unless queue_name specified. Not supported with ActiveRecord 2.x. Default is nil. DO NOT USE together with queue name.
   EOS
 
   needs 'active_record', 'yaml', 'erb'
@@ -65,6 +68,11 @@ class MonitorDelayedJobs < Scout::Plugin
       if option(:queue_name)
         query_hash.keys.each do |key|
           query_hash[key] = query_hash[key].where('queue = ?', option(:queue_name))
+        end
+      end
+      if option(:excluded_queue_name)
+        query_hash.keys.each do |key|
+          query_hash[key] = query_hash[key].where('queue <> ?', option(:excluded_queue_name))
         end
       end
     else

--- a/delayed_job/monitor_delayed_jobs.rb
+++ b/delayed_job/monitor_delayed_jobs.rb
@@ -1,8 +1,6 @@
 $VERBOSE=false
 
 class MonitorDelayedJobs < Scout::Plugin
-  ONE_DAY    = 60 * 60 * 24
-
   OPTIONS=<<-OPTIONS_DESCRIPTION_YAML
   path_to_app:
     name: Full Path to the Rails Application

--- a/delayed_job/monitor_delayed_jobs.rb
+++ b/delayed_job/monitor_delayed_jobs.rb
@@ -3,7 +3,7 @@ $VERBOSE=false
 class MonitorDelayedJobs < Scout::Plugin
   ONE_DAY    = 60 * 60 * 24
 
-  OPTIONS=<<-EOS
+  OPTIONS=<<-OPTIONS_DESCRIPTION_YAML
   path_to_app:
     name: Full Path to the Rails Application
     notes: "The full path to the Rails application (ex: /var/www/apps/APP_NAME/current)."
@@ -12,127 +12,150 @@ class MonitorDelayedJobs < Scout::Plugin
     default: production
   queue_name:
     name: Queue Name
-    notes: If specified, only gather the metrics for jobs in this specific queue name. When nil, aggregate metrics from all queues. Not supported with ActiveRecord 2.x. Default is nil
+    notes: If specified, only gather the metrics for jobs in this specific queue name. When nil, aggregate metrics from all queues, unless exclude_queue_name is specified. Default is nil
   exclude_queue_name:
     name: Exclude Queue Name
-    notes: If specified, do not gather the metrics for jobs in this specific queue name. When nil, aggregate metrics from all queues, unless queue_name specified. Not supported with ActiveRecord 2.x. Default is nil.
-  EOS
+    notes: If specified, do not gather the metrics for jobs in this specific queue name. When nil, aggregate metrics from all queues, unless queue_name specified. Default is nil.
+  OPTIONS_DESCRIPTION_YAML
 
-  needs 'active_record', 'yaml', 'erb'
+  needs 'active_record', 'active_support', 'yaml', 'erb'
 
   require 'thread'
   # IMPORTANT! Requiring Rubygems is NOT a best practice. See http://scoutapp.com/info/creating_a_plugin#libraries
   # This plugin is an exception because we to subclass ActiveRecord::Base before the plugin's build_report method is run.
   require 'rubygems'
   require 'active_record'
+
+
+  class DbConnError < StandardError; end
   class DelayedJob < ActiveRecord::Base; end
   DelayedJob.default_timezone = :utc
 
+
+  QUERY_DEFS = {
+    :total => {
+      :sql => 'id IS NOT NULL'
+    },
+    # Jobs that are currently being run by workers
+    :running => {
+      :sql => 'locked_at IS NOT NULL AND failed_at IS NULL'
+    },
+    # Jobs that are ready to run but haven't ever been run
+    :waiting => {
+      :sql => 'run_at <= ? AND locked_at IS NULL AND attempts = 0', :args => [ Time.now.utc ]
+    },
+    # Jobs that haven't ever been run but are not set to run until later
+    :scheduled => {
+      :sql => 'run_at > ? AND locked_at IS NULL AND attempts = 0', :args => [ Time.now.utc ]
+    },
+    # Jobs that aren't running that have failed at least once
+    :failing => {
+      :sql => 'attempts > 0 AND failed_at IS NULL AND locked_at IS NULL'
+    },
+    # Jobs that have permanently failed
+    :failed => {
+      :sql => 'failed_at IS NOT NULL'
+    },
+    # The oldest job that hasn't yet been run, in minutes
+    :oldest => {
+      :sql => 'run_at <= ? AND locked_at IS NULL AND attempts = 0', :args => [ Time.now.utc ],
+      :select => 'MIN(run_at) as run_at',
+      :calc => Proc.new do |query|
+        begin
+          ((Time.now.utc - query.first.run_at) / 60).floor
+        rescue
+          0
+        end
+      end
+    }
+  }.freeze
+
   def build_report
+    setup_database_connection
+
+    report_hash = Hash.new
+    QUERY_DEFS.each do |name, criteria|
+      sql = criteria[:sql] + queue_filter_sql
+      args = criteria.fetch(:args, [])
+      args << queue_filter_params if queue_filter_params
+      query_conditions = args.unshift(sql)
+
+      if DelayedJob.respond_to?(:where)
+        #
+        # ActiveRecord >= 3.x uses AREL query format
+        #
+        report_hash[name] = if criteria[:select]
+                              query = DelayedJob.select(criteria[:select]).where(query_conditions)
+                              if criteria[:calc].respond_to? :call
+                                criteria[:calc].call(query)
+                              else
+                                query
+                              end
+                            else
+                              DelayedJob.where(query_conditions).count
+                            end
+
+      else
+        #
+        # ActiveRecord 2.x compatible
+        #
+        report_hash[name] = if criteria[:select]
+                              query = DelayedJob.find_by_sql [
+                                "SELECT #{criteria[:select]} FROM #{DelayedJob.table_name} WHERE #{query_conditions.shift}",
+                                *query_conditions
+                              ]
+                              if criteria[:calc].respond_to? :call
+                                criteria[:calc].call(query)
+                              else
+                                query
+                              end
+                            else
+                              DelayedJob.count(:all, :conditions => query_conditions)
+                            end
+      end
+
+    end
+
+    #report_hash[:queue] = option(:queue_name) || "except #{option(:exclude_queue_name)}"
+
+    report(report_hash)
+
+  rescue DbConnError => err
+    STDERR.puts "ERROR: #{err.message} connecting to database"
+  end
+
+private
+  def setup_database_connection
     app_path = option(:path_to_app)
 
     # Ensure path to db config provided
     if !app_path or app_path.empty?
-      return error("The path to the Rails Application wasn't provided.","Please provide the full path to the Rails Application (ie - /var/www/apps/APP_NAME/current)")
+      raise DbConnError.new("The path to the Rails Application wasn't provided.","Please provide the full path to the Rails Application (ie - /var/www/apps/APP_NAME/current)")
     end
 
     db_config_path = app_path + '/config/database.yml'
 
-    if !File.exist?(db_config_path)
-      return error("The database config file could not be found.", "The database config file could not be found at: #{db_config_path}. Please ensure the path to the Rails Application is correct.")
+    unless File.exist?(db_config_path)
+      raise DbConnError.new("The database config file could not be found.", "The database config file could not be found at: #{db_config_path}. Please ensure the path to the Rails Application is correct.")
     end
 
     db_config = YAML::load(ERB.new(File.read(db_config_path)).result)
     ActiveRecord::Base.establish_connection(db_config[option(:rails_env)])
+    #ActiveRecord::Base.logger = Logger.new(STDOUT) if "production" != option(:rails_env)
+    ActiveRecord::Base.connection.instance_variable_set :@logger, Logger.new(STDOUT)
+  end
 
-    # The hash which will store the query commands.
-    query_hash = Hash.new
+  def queue_filter_params
+    @queue_filter_params ||= option(:queue_name) || option(:exclude_queue_name)
+  end
 
-    if DelayedJob.respond_to?(:where)
-      # ActiveRecord >= 3.x uses AREL query format
-      # All jobs
-      query_hash[:total]     = DelayedJob
-      # Jobs that are currently being run by workers
-      query_hash[:running]   = DelayedJob.where('locked_at IS NOT NULL AND failed_at IS NULL')
-      # Jobs that are ready to run but haven't ever been run
-      query_hash[:waiting]   = DelayedJob.where('run_at <= ? AND locked_at IS NULL AND attempts = 0', Time.now.utc)
-      # Jobs that haven't ever been run but are not set to run until later
-      query_hash[:scheduled] = DelayedJob.where('run_at > ? AND locked_at IS NULL AND attempts = 0', Time.now.utc)
-      # Jobs that aren't running that have failed at least once
-      query_hash[:failing]   = DelayedJob.where('attempts > 0 AND failed_at IS NULL AND locked_at IS NULL')
-      # Jobs that have permanently failed
-      query_hash[:failed]    = DelayedJob.where('failed_at IS NOT NULL')
-      # The oldest job that hasn't yet been run, in minutes
-      query_hash[:oldest]    = DelayedJob.where('run_at <= ? AND locked_at IS NULL AND attempts = 0', Time.now.utc).order(:run_at)
-
-      if option(:queue_name)
-        query_hash.keys.each do |key|
-          query_hash[key] = query_hash[key].where('queue = ?', option(:queue_name))
-        end
-      end
-      if option(:exclude_queue_name)
-        query_hash.keys.each do |key|
-          query_hash[key] = query_hash[key].where('queue <> ? or queue IS NULL', option(:exclude_queue_name))
-        end
-      end
-    else
-      # ActiveRecord 2.x compatible
-      queue_filter_sql = ""
-      queue_filter_params = nil
-      if option(:queue_name)
-        queue_filter_sql = " and queue = ?"
-        queue_filter_params = option(:queue_name)
-      end
-      if option(:exclude_queue_name)
-        queue_filter_sql = " and ( queue <> ? or queue IS NULL )"
-        queue_filter_params = option(:exclude_queue_name)
-      end
-      # All jobs
-      if queue_filter_params
-        query_hash[:total]    = DelayedJob.find(:all, :conditions => [queue_filter_sql.gsub(" and ",""),queue_filter_params])
-      else
-        query_hash[:total]    = DelayedJob
-      end
-      # Jobs that are currently being run by workers
-      conditions = ["locked_at IS NOT NULL AND failed_at IS NULL #{queue_filter_sql}"]
-      conditions << queue_filter_params if queue_filter_params
-      query_hash[:running]   = DelayedJob.find(:all, :conditions => conditions)
-      # Jobs that are ready to run but haven't ever been run
-      conditions = ["run_at <= ? AND locked_at IS NULL AND attempts = 0 #{queue_filter_sql}", Time.now.utc]
-      conditions << queue_filter_params if queue_filter_params
-      query_hash[:waiting]   = DelayedJob.find(:all, :conditions => conditions)
-      # Jobs that haven't ever been run but are not set to run until later
-      conditions = ["run_at > ? AND locked_at IS NULL AND attempts = 0 #{queue_filter_sql}", Time.now.utc]
-      conditions << queue_filter_params if queue_filter_params
-      query_hash[:scheduled] = DelayedJob.find(:all, :conditions => conditions)
-      # Jobs that aren't running that have failed at least once
-      conditions = ["attempts > 0 AND failed_at IS NULL AND locked_at IS NULL #{queue_filter_sql}"]
-      conditions << queue_filter_params if queue_filter_params
-      query_hash[:failing]   = DelayedJob.find(:all, :conditions => conditions)
-      # Jobs that have permanently failed
-      conditions = ["failed_at IS NOT NULL #{queue_filter_sql}"]
-      conditions << queue_filter_params if queue_filter_params
-      query_hash[:failed]    = DelayedJob.find(:all, :conditions => conditions)
-      # The oldest job that hasn't yet been run, in minutes
-      conditions = ["run_at <= ? AND locked_at IS NULL AND attempts = 0 #{queue_filter_sql}", Time.now.utc]
-      conditions << queue_filter_params if queue_filter_params
-      query_hash[:oldest]    = DelayedJob.find(:all, :conditions => conditions, :order => :run_at)
-    end
-
-    report_hash = Hash.new
-
-    # Execute .count on these query_hash keys and store in report_hash
-    query_hash.keys.select{|k| [:total, :running, :waiting, :scheduled, :failing, :failed].include?(k)}.each do |key|
-      report_hash[key] = query_hash[key].count
-    end
-
-    # The oldest job that hasn't yet been run, in minutes
-    if oldest = query_hash[:oldest].first
-      report_hash[:oldest] = (Time.now.utc - oldest.run_at) / 60
-    else
-      report_hash[:oldest] = 0
-    end
-
-    report(report_hash)
+  def queue_filter_sql
+    @queue_filter_sql ||= if option(:queue_name)
+                            ' AND queue = ?'
+                          elsif option(:exclude_queue_name)
+                            ' AND ( queue <> ? or queue IS NULL )'
+                          else
+                            ''
+                          end
   end
 end


### PR DESCRIPTION
1) New options called exclude_queue_name which gets all data for DJ except the specified queue
2) Added support for ActiveRecord 2 