### PR TITLE
Update sphinx monitoring for sphinx v2.x

### DIFF
--- a/sphinx_monitor/sphinx_monitor.rb
+++ b/sphinx_monitor/sphinx_monitor.rb
@@ -149,9 +149,9 @@ class SphinxMonitor < Scout::Plugin
     else
       return nil
     end
-    step = if line.match('rotating finished')
+    step = if line.match('rotating finished') || line.match('all indexes done')
              :finish
-           elsif line.match('rotating indices')
+           elsif line.match('rotating indices') || line.match('caught SIGHUP')
              :start
            else
              :intermediate


### PR DESCRIPTION
In sphinx v2, the logging output has changed, so we need to match on the
new output. This change is backwards compatible and will match on sphinx
v1 and v2.
